### PR TITLE
chore!: bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/audit",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/audit",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@gliff-ai/annotate": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gliff-ai/audit",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "gliff.ai AUDIT",
   "repository": "git://github.com/gliff-ai/audit.git",
   "main": "dist/index.es.js",


### PR DESCRIPTION
as it says on the tin - should force a breaking change bumping us to v1.0.0; this makes dep management in DOMINATE easier