### PR TITLE
feat!: Added imageData to productsNavbar

### DIFF
--- a/src/components/ProjectAuditTable.tsx
+++ b/src/components/ProjectAuditTable.tsx
@@ -10,7 +10,7 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import { AuditAction } from "@gliff-ai/annotate";
 
-import { AnnotationSession } from "@/index";
+import { AnnotationSession, ImageData } from "@/index";
 
 const useStyles = makeStyles(() => ({
   tableText: {
@@ -24,6 +24,7 @@ interface Props {
   searchField: string;
   searchValue: string;
   setAudit: (audit: AuditAction[]) => void;
+  setProductsNavbarImageData: (imageName: ImageData) => void;
 }
 
 export const ProjectAuditTable = (props: Props): ReactElement => {
@@ -55,6 +56,10 @@ export const ProjectAuditTable = (props: Props): ReactElement => {
                 key={`${session.timestamp}`}
                 onClick={() => {
                   props.setAudit(session.audit);
+                  props.setProductsNavbarImageData({
+                    imageName: session?.imagename,
+                    imageUid: session?.imageUid,
+                  });
                 }}
                 style={{ cursor: "pointer" }}
               >

--- a/src/components/ProjectAuditTable.tsx
+++ b/src/components/ProjectAuditTable.tsx
@@ -24,7 +24,7 @@ interface Props {
   searchField: string;
   searchValue: string;
   setAudit: (audit: AuditAction[]) => void;
-  setProductsNavbarImageData: (imageName: ImageData) => void;
+  setProductsNavbarImageData: (imageData: ImageData) => void;
 }
 
 export const ProjectAuditTable = (props: Props): ReactElement => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,20 +58,27 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+export interface ImageData {
+  imageName: string;
+  imageUid: string;
+}
+
 export interface AnnotationSession {
   timestamp: number;
   username: string;
   imagename: string;
   audit: AuditAction[];
+  imageUid: string;
 }
 
 interface Props {
   showAppBar: boolean;
   sessions: AnnotationSession[];
+  setProductsNavbarImageData: (imageName: ImageData) => void;
 }
 
 const UserInterface = (props: Props): ReactElement => {
-  const { showAppBar } = props;
+  const { showAppBar, setProductsNavbarImageData } = props;
   const classes = useStyles();
 
   const [searchField, setSearchField] = useState<string>(""); // search field
@@ -131,7 +138,13 @@ const UserInterface = (props: Props): ReactElement => {
                       <IconButton
                         tooltip={{ name: "Back" }}
                         icon={icons.arrowLeft}
-                        onClick={() => setAudit(null)}
+                        onClick={() => {
+                          setAudit(null);
+                          setProductsNavbarImageData({
+                            imageName: "",
+                            imageUid: "",
+                          });
+                        }}
                         size="large"
                       />
                     )}
@@ -154,6 +167,7 @@ const UserInterface = (props: Props): ReactElement => {
                       searchField={searchField}
                       searchValue={searchValue}
                       setAudit={setAudit}
+                      setProductsNavbarImageData={setProductsNavbarImageData}
                     />
                   )}
                 </Card>


### PR DESCRIPTION
## Description

Added imageName and imageUid to annotation session in order to allow dominate to request this information and display them in the productsNavbar

Don't forget to reference all other pull requests which are associated to this one below: e.g.

relates [gliff-ai/dominate#306](https://github.com/gliff-ai/dominate/issues/306)

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings.

