### PR TITLE
feat: do monthly major and daily gliff scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,28 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
-      - "gliff-ai/frontend"
+      - "gliff-ai/ci-cd"
+    commit-message:
+      prefix: "chore: "
   - package-ecosystem: "npm"
+    # ignore all minor and patch updates as these will be caught by gliff-ai-robot
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "gliff-ai/frontend"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "npm"
+    # update gliff packages very regularly
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "gliff-ai/frontend"
+    ignore:
+      - dependency-name: "@gliff-ai/*"


### PR DESCRIPTION
## Description

This is a CI/CD change that moves dependabot to doing monthly checks for major version updates. We already do minor/patch updates with one of our own actions on a weekly basis.